### PR TITLE
ci: adding timezone on scheduled crontab

### DIFF
--- a/.github/workflows/codeql_check.yaml
+++ b/.github/workflows/codeql_check.yaml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [ "main" ]
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
+      timezone: "Europe/Paris"
 
 jobs:
   analyze:

--- a/.github/workflows/update_pages.yaml
+++ b/.github/workflows/update_pages.yaml
@@ -2,7 +2,8 @@ name: CD | Update deployed github pages
 
 on:
   schedule:
-    - cron: '0 1,7,13,19 * * *'
+    - cron: "0 1,7,13,19 * * *"
+      timezone: "Europe/Paris"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Objectives

Use new timezone key on ci with cron schedule to fix summer/winter time.
